### PR TITLE
Update the r_cutoff to make them consistent

### DIFF
--- a/Tutorials/SBM_AA.ipynb
+++ b/Tutorials/SBM_AA.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "sbm_AA = SBM(name='2ci2', time_step=0.002, collision_rate=1.0, r_cutoff=1.5, temperature=0.5)"
+    "sbm_AA = SBM(name='2ci2', time_step=0.002, collision_rate=1.0, r_cutoff=0.65, temperature=0.5)"
    ],
    "outputs": [],
    "metadata": {}

--- a/Tutorials/SBM_CA.ipynb
+++ b/Tutorials/SBM_CA.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "sbm_CA = SBM(name='2ci2', time_step=0.0005, collision_rate=1.0, r_cutoff=3.0, temperature=0.5)"
+    "sbm_CA = SBM(name='2ci2', time_step=0.0005, collision_rate=1.0, r_cutoff=1.1, temperature=0.5)"
    ],
    "outputs": [],
    "metadata": {}


### PR DESCRIPTION
Also, the files used in OpenSMOG tutorial website (https://opensmog.readthedocs.io/en/latest/Tutorials/SBM_AA.html) and (https://opensmog.readthedocs.io/en/latest/Tutorials/SBM_CA.html) are not from the main branch but from the branch of Docs, which is even more outdated. 